### PR TITLE
Psr7RequestFactory::fromNette() preserves original raw body

### DIFF
--- a/src/Psr7RequestFactory.php
+++ b/src/Psr7RequestFactory.php
@@ -2,9 +2,9 @@
 
 namespace Contributte\Psr7;
 
-use GuzzleHttp\Psr7\LazyOpenStream;
 use Nette\Http\IRequest;
 use Nette\Http\RequestFactory;
+use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * @author Milan Felix Sulc <sulcmil@gmail.com>
@@ -32,7 +32,7 @@ class Psr7RequestFactory
 			$request->getMethod(),
 			$request->getUrl() ? Psr7UriFactory::fromNette($request->getUrl()) : NULL,
 			$request->getHeaders(),
-			new LazyOpenStream('php://input', 'r+'),
+			stream_for($request->getRawBody()),
 			str_replace('HTTP/', '', $request->getHeader('SERVER_PROTOCOL', '1.1'))
 		);
 

--- a/src/Psr7ServerRequestFactory.php
+++ b/src/Psr7ServerRequestFactory.php
@@ -2,9 +2,9 @@
 
 namespace Contributte\Psr7;
 
-use GuzzleHttp\Psr7\LazyOpenStream;
 use Nette\Http\IRequest;
 use Nette\Http\RequestFactory;
+use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * @author Milan Felix Sulc <sulcmil@gmail.com>
@@ -40,7 +40,7 @@ class Psr7ServerRequestFactory
 			$request->getMethod(),
 			$request->getUrl() ? Psr7UriFactory::fromNette($request->getUrl()) : NULL,
 			$request->getHeaders(),
-			new LazyOpenStream('php://input', 'r+'),
+			stream_for($request->getRawBody()),
 			str_replace('HTTP/', '', $request->getHeader('SERVER_PROTOCOL', '1.1')),
 			$_SERVER
 		);

--- a/tests/cases/Psr7ServerRequestFactory.phpt
+++ b/tests/cases/Psr7ServerRequestFactory.phpt
@@ -32,6 +32,26 @@ test(function () {
 	Assert::equal(['foo' => 'bar'], $request->getParsedBody());
 });
 
+// RawBody
+test(function () {
+	$nette = new Request(
+		new UrlScript('https://nette.org'),
+		NULL,
+		NULL,
+		NULL,
+		NULL,
+		NULL,
+		NULL,
+		NULL,
+		NULL,
+		function () {
+			return '{"foo":"bar"}';
+		}
+	);
+	$request = Psr7ServerRequestFactory::fromNette($nette);
+	Assert::same('{"foo":"bar"}', (string) $request->getBody());
+});
+
 // Global
 test(function () {
 	$_SERVER['REQUEST_METHOD'] = 'POST';


### PR DESCRIPTION
Motivation behind this change: I am writing a library for handling webhooks, in which the `WebhookHandler::handle()` expects PSR-7 request. But there is also a Nette bridge with a presenter that simply converts the `Nette\Http\IRequest` to the PSR-7 implementation and passes it to the handler. I wanted to use this adapter, but the tests for the presenter failed because the raw body in the mocked `Nette\Http\IRequest` was ignored.

I'm not sure about performance implications, because the body is not retrieved lazily anymore. If 
that is a problem, I'll have to come up with some more thorough solution.