### PR TITLE
Fix incompatible interface

### DIFF
--- a/src/Extra/ExtraRequestTrait.php
+++ b/src/Extra/ExtraRequestTrait.php
@@ -2,6 +2,7 @@
 
 namespace Contributte\Psr7\Extra;
 
+use Contributte\Psr7\Psr7Request;
 use Contributte\Psr7\Psr7Stream;
 use Contributte\Psr7\Psr7Uri;
 
@@ -57,7 +58,10 @@ trait ExtraRequestTrait
 	 * URI *********************************************************************
 	 */
 
-	public function withNewUri(string $uri): self
+	/**
+	 * @return Psr7Request|self
+	 */
+	public function withNewUri(string $uri)
 	{
 		return $this->withUri(new Psr7Uri($uri));
 	}

--- a/src/Extra/ExtraResponseTrait.php
+++ b/src/Extra/ExtraResponseTrait.php
@@ -14,9 +14,9 @@ trait ExtraResponseTrait
 
 	/**
 	 * @param mixed $body
-	 * @return Psr7Response
+	 * @return Psr7Response|self
 	 */
-	public function appendBody($body): self
+	public function appendBody($body)
 	{
 		$this->getBody()->write($body);
 
@@ -24,9 +24,9 @@ trait ExtraResponseTrait
 	}
 
 	/**
-	 * @return Psr7Response
+	 * @return Psr7Response|self
 	 */
-	public function rewindBody(): self
+	public function rewindBody()
 	{
 		$this->getBody()->rewind();
 
@@ -35,9 +35,9 @@ trait ExtraResponseTrait
 
 	/**
 	 * @param mixed $body
-	 * @return Psr7Response
+	 * @return Psr7Response|self
 	 */
-	public function writeBody($body): self
+	public function writeBody($body)
 	{
 		$this->getBody()->write($body);
 
@@ -46,9 +46,9 @@ trait ExtraResponseTrait
 
 	/**
 	 * @param mixed[] $data
-	 * @return Psr7Response
+	 * @return Psr7Response|self
 	 */
-	public function writeJsonBody(array $data): self
+	public function writeJsonBody(array $data)
 	{
 		return $this
 			->writeBody(json_encode($data))
@@ -56,9 +56,9 @@ trait ExtraResponseTrait
 	}
 
 	/**
-	 * @return Psr7Response
+	 * @return Psr7Response|self
 	 */
-	public function writeJsonObject(JsonSerializable $object): self
+	public function writeJsonObject(JsonSerializable $object)
 	{
 		return $this
 			->writeBody(json_encode($object))
@@ -91,9 +91,9 @@ trait ExtraResponseTrait
 
 	/**
 	 * @param string[]|string[][] $headers
-	 * @return Psr7Response
+	 * @return Psr7Response|self
 	 */
-	public function withHeaders(array $headers): self
+	public function withHeaders(array $headers)
 	{
 		$new = clone $this;
 		foreach ($headers as $key => $value) {

--- a/src/Nette/NetteRequestTrait.php
+++ b/src/Nette/NetteRequestTrait.php
@@ -2,6 +2,7 @@
 
 namespace Contributte\Psr7\Nette;
 
+use Contributte\Psr7\Psr7Request;
 use Nette\Application\Request as ApplicationRequest;
 use Nette\Http\IRequest as HttpRequest;
 
@@ -19,7 +20,10 @@ trait NetteRequestTrait
 		return $this->httpRequest;
 	}
 
-	public function withHttpRequest(HttpRequest $request): self
+	/**
+	 * @return Psr7Request|self
+	 */
+	public function withHttpRequest(HttpRequest $request)
 	{
 		$new = clone $this;
 		$new->httpRequest = $request;
@@ -32,7 +36,10 @@ trait NetteRequestTrait
 		return $this->applicationRequest;
 	}
 
-	public function withApplicationRequest(ApplicationRequest $request): self
+	/**
+	 * @return Psr7Request|self
+	 */
+	public function withApplicationRequest(ApplicationRequest $request)
 	{
 		$new = clone $this;
 		$new->applicationRequest = $request;

--- a/src/Nette/NetteResponseTrait.php
+++ b/src/Nette/NetteResponseTrait.php
@@ -13,13 +13,13 @@ use Nette\Http\Response;
 trait NetteResponseTrait
 {
 
-	/** @var IHttpResponse */
+	/** @var IHttpResponse|null */
 	protected $httpResponse;
 
-	/** @var IApplicationResponse */
+	/** @var IApplicationResponse|null */
 	protected $applicationResponse;
 
-	public function getHttpResponse(): IHttpResponse
+	public function getHttpResponse(): ?IHttpResponse
 	{
 		return $this->httpResponse;
 	}
@@ -40,7 +40,7 @@ trait NetteResponseTrait
 		return $this->httpResponse !== null;
 	}
 
-	public function getApplicationResponse(): IApplicationResponse
+	public function getApplicationResponse(): ?IApplicationResponse
 	{
 		return $this->applicationResponse;
 	}

--- a/src/Nette/NetteResponseTrait.php
+++ b/src/Nette/NetteResponseTrait.php
@@ -3,6 +3,7 @@
 namespace Contributte\Psr7\Nette;
 
 use Contributte\Psr7\Exception\Logical\InvalidStateException;
+use Contributte\Psr7\Psr7Response;
 use Nette\Application\Application;
 use Nette\Application\IResponse as IApplicationResponse;
 use Nette\Http\IResponse as IHttpResponse;
@@ -23,7 +24,10 @@ trait NetteResponseTrait
 		return $this->httpResponse;
 	}
 
-	public function withHttpResponse(IHttpResponse $response): self
+	/**
+	 * @return Psr7Response|self
+	 */
+	public function withHttpResponse(IHttpResponse $response)
 	{
 		$new = clone $this;
 		$new->httpResponse = $response;
@@ -41,7 +45,10 @@ trait NetteResponseTrait
 		return $this->applicationResponse;
 	}
 
-	public function withApplicationResponse(IApplicationResponse $response): self
+	/**
+	 * @return Psr7Response|self
+	 */
+	public function withApplicationResponse(IApplicationResponse $response)
 	{
 		$new = clone $this;
 		$new->applicationResponse = $response;

--- a/src/ProxyRequest.php
+++ b/src/ProxyRequest.php
@@ -274,8 +274,9 @@ class ProxyRequest implements ServerRequestInterface
 	 * @see getAttributes()
 	 * @param string $name
 	 * @param mixed  $default
+	 * @return mixed
 	 */
-	public function getAttribute($name, $default = null): self
+	public function getAttribute($name, $default = null)
 	{
 		return $this->inner->getAttribute($name, $default);
 	}

--- a/src/Psr7RequestFactory.php
+++ b/src/Psr7RequestFactory.php
@@ -23,7 +23,7 @@ class Psr7RequestFactory
 			Psr7UriFactory::fromNette($request->getUrl()),
 			$request->getHeaders(),
 			stream_for($request->getRawBody()),
-			str_replace('HTTP/', '', $request->getHeader('SERVER_PROTOCOL', '1.1'))
+			str_replace('HTTP/', '', $request->getHeader('SERVER_PROTOCOL', '1.1') ?? '')
 		);
 
 		// Nette-compatibility

--- a/src/Psr7ServerRequestFactory.php
+++ b/src/Psr7ServerRequestFactory.php
@@ -28,7 +28,7 @@ class Psr7ServerRequestFactory
 			Psr7UriFactory::fromNette($request->getUrl()),
 			$request->getHeaders(),
 			stream_for($request->getRawBody()),
-			str_replace('HTTP/', '', $request->getHeader('SERVER_PROTOCOL', '1.1')),
+			str_replace('HTTP/', '', $request->getHeader('SERVER_PROTOCOL', '1.1') ?? ''),
 			$_SERVER
 		);
 


### PR DESCRIPTION
phpstan failed and there was no reason to test these simple wrapper methods so no-one noticed php consider return self in traits always as incompatible interface.

`getAttribute($name, $default = null): self` was my mistake. I moved typehint from annotation without check if it's right.