### PR TITLE
Fix immutability of ProxyResponse when using ProxyResponse::withHeader()

### DIFF
--- a/src/ProxyResponse.php
+++ b/src/ProxyResponse.php
@@ -88,9 +88,10 @@ class ProxyResponse implements ResponseInterface
 	 */
 	public function withHeader($name, $value): self
 	{
-		$this->inner = $this->inner->withHeader($name, $value);
+		$new = clone $this;
+		$new->inner = $this->inner->withHeader($name, $value);
 
-		return $this;
+		return $new;
 	}
 
 	/**

--- a/tests/cases/ProxyResponse.phpt
+++ b/tests/cases/ProxyResponse.phpt
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Test: ProxyResponse
+ */
+
+use Contributte\Psr7\ProxyResponse;
+use Contributte\Psr7\Psr7ResponseFactory;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+// withHeader
+test(function (): void {
+	$response = Psr7ResponseFactory::fromGlobal();
+
+	$proxy = new ProxyResponse($response);
+
+	Assert::same(
+		['application/json'],
+		$proxy->withHeader('Content-Type', 'application/json')->getHeader('Content-Type')
+	);
+
+	Assert::same($response, $proxy->getOriginalResponse());
+});


### PR DESCRIPTION
Right now this method does not clone the instance, but it mutates it. 