### PR TITLE
Remove self type hints from traits to fix compability with PHP <7.4

### DIFF
--- a/src/Extra/ExtraRequestTrait.php
+++ b/src/Extra/ExtraRequestTrait.php
@@ -61,7 +61,7 @@ trait ExtraRequestTrait
 	/**
 	 * @return static
 	 */
-	public function withNewUri(string $uri): self
+	public function withNewUri(string $uri)
 	{
 		return $this->withUri(new Psr7Uri($uri));
 	}

--- a/src/Extra/ExtraResponseTrait.php
+++ b/src/Extra/ExtraResponseTrait.php
@@ -16,7 +16,7 @@ trait ExtraResponseTrait
 	 * @param string $body
 	 * @return static
 	 */
-	public function appendBody(string $body): self
+	public function appendBody(string $body)
 	{
 		$this->getBody()->write($body);
 
@@ -26,7 +26,7 @@ trait ExtraResponseTrait
 	/**
 	 * @return static
 	 */
-	public function rewindBody(): self
+	public function rewindBody()
 	{
 		$this->getBody()->rewind();
 
@@ -37,7 +37,7 @@ trait ExtraResponseTrait
 	 * @param string $body
 	 * @return static
 	 */
-	public function writeBody(string $body): self
+	public function writeBody(string $body)
 	{
 		$this->getBody()->write($body);
 
@@ -48,7 +48,7 @@ trait ExtraResponseTrait
 	 * @param mixed[] $data
 	 * @return static
 	 */
-	public function writeJsonBody(array $data): self
+	public function writeJsonBody(array $data)
 	{
 		return $this
 			->writeBody(Json::encode($data))
@@ -58,7 +58,7 @@ trait ExtraResponseTrait
 	/**
 	 * @return static
 	 */
-	public function writeJsonObject(JsonSerializable $object): self
+	public function writeJsonObject(JsonSerializable $object)
 	{
 		return $this
 			->writeBody(Json::encode($object))
@@ -93,7 +93,7 @@ trait ExtraResponseTrait
 	 * @param string[]|string[][] $headers
 	 * @return static
 	 */
-	public function withHeaders(array $headers): self
+	public function withHeaders(array $headers)
 	{
 		$new = clone $this;
 		foreach ($headers as $key => $value) {


### PR DESCRIPTION
Without this fix the following error was thrown `Declaration of Contributte\Psr7\Extra\ExtraRequestTrait::withNewUri(string $uri): Contributte\Psr7\Extra\ExtraRequestTrait must be compatible with Contributte\Psr7\ProxyRequest::withNewUri(string $uri): Contributte\Psr7\ProxyRequest` on PHP 7.4.